### PR TITLE
dotest.py: add timeout option

### DIFF
--- a/bugs/ex32.inf
+++ b/bugs/ex32.inf
@@ -69,9 +69,9 @@ That's one healthy cow.
 >dan, x conscience
 "That I can do," says Dan. "I'm empty-handed."
 
-# The following test puts the 6/11 library into an infinite loop! So I've commented it out.
+# The following test puts the 6/11 library into an infinite loop!
 
-# >dan, x
-# (the cow pie)
-# "What," says Dan, "you want me to examine the cow pie?"
+>dan, x
+(the cow pie)
+"What," says Dan, "you want me to examine the cow pie?"
 


### PR DESCRIPTION
Adds a -t (--timeout) option to dotest.py, setting a timeout on reading a single update (accept_update).
Restores the infinitely looping test in bugs/ex32.inf now that timeouts are in place.

Notes:
-The timeout value is a float representing seconds. We prevent it from being negative or NaN. We don't impose any upper limits, although values > 100,000,000 secs produce an invalid arg error from select on my box.
-The default timeout is 1 sec. I began to see test timeouts for the existing tests when I decreased the value below 0.02 secs.
-optparse has been deprecated in favor of the similar argparse module. I left the program as-is, wanting to change as little as possible, but we might consider upgrading in the future so that we'll benefit from future development.
-The timeout applies to the process of reading a single update from the remote interpreter, not to a test as a whole. We could change this if we want the timeout to cover an entire test.
-The configured timeout value applies to all tests. I considered using the **keyword:value test syntax to allow individual tests to override the default timeout. In this scenario we might also add a --max-timeout option and prevent a test from defining a value greater than the max. This would keep a broken or malicious test from holding up the entire test run for an unreasonable length of time.
